### PR TITLE
Fixed Dataset file path to target the main branch in repository

### DIFF
--- a/project_part1.ipynb
+++ b/project_part1.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6c7ffefd",
+   "id": "777e6ab3",
    "metadata": {
     "papermill": {
-     "duration": 0.003746,
-     "end_time": "2023-11-02T14:59:54.911365",
+     "duration": 0.005199,
+     "end_time": "2023-11-02T15:25:33.033992",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.907619",
+     "start_time": "2023-11-02T15:25:33.028793",
      "status": "completed"
     },
     "tags": []
@@ -36,13 +36,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b511e03",
+   "id": "5195de6f",
    "metadata": {
     "papermill": {
-     "duration": 0.002632,
-     "end_time": "2023-11-02T14:59:54.918813",
+     "duration": 0.004434,
+     "end_time": "2023-11-02T15:25:33.045452",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.916181",
+     "start_time": "2023-11-02T15:25:33.041018",
      "status": "completed"
     },
     "tags": []
@@ -76,13 +76,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b77e5f",
+   "id": "4bb6ddb8",
    "metadata": {
     "papermill": {
-     "duration": 0.002588,
-     "end_time": "2023-11-02T14:59:54.924153",
+     "duration": 0.004394,
+     "end_time": "2023-11-02T15:25:33.054575",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.921565",
+     "start_time": "2023-11-02T15:25:33.050181",
      "status": "completed"
     },
     "tags": []
@@ -93,13 +93,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3818ef3b",
+   "id": "b82d55ca",
    "metadata": {
     "papermill": {
-     "duration": 0.002625,
-     "end_time": "2023-11-02T14:59:54.929571",
+     "duration": 0.004352,
+     "end_time": "2023-11-02T15:25:33.063623",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.926946",
+     "start_time": "2023-11-02T15:25:33.059271",
      "status": "completed"
     },
     "tags": []
@@ -111,13 +111,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b700946",
+   "id": "aac51c5a",
    "metadata": {
     "papermill": {
-     "duration": 0.002636,
-     "end_time": "2023-11-02T14:59:54.935079",
+     "duration": 0.004545,
+     "end_time": "2023-11-02T15:25:33.073411",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.932443",
+     "start_time": "2023-11-02T15:25:33.068866",
      "status": "completed"
     },
     "tags": []
@@ -137,19 +137,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fdaf5bf7",
+   "id": "d2cea27e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-11-02T14:59:54.942853Z",
-     "iopub.status.busy": "2023-11-02T14:59:54.942488Z",
-     "iopub.status.idle": "2023-11-02T14:59:55.269190Z",
-     "shell.execute_reply": "2023-11-02T14:59:55.268079Z"
+     "iopub.execute_input": "2023-11-02T15:25:33.085045Z",
+     "iopub.status.busy": "2023-11-02T15:25:33.084496Z",
+     "iopub.status.idle": "2023-11-02T15:25:33.526124Z",
+     "shell.execute_reply": "2023-11-02T15:25:33.524531Z"
     },
     "papermill": {
-     "duration": 0.333219,
-     "end_time": "2023-11-02T14:59:55.271201",
+     "duration": 0.451136,
+     "end_time": "2023-11-02T15:25:33.529318",
      "exception": false,
-     "start_time": "2023-11-02T14:59:54.937982",
+     "start_time": "2023-11-02T15:25:33.078182",
      "status": "completed"
     },
     "tags": []
@@ -177,13 +177,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af77ca6e",
+   "id": "85243ab5",
    "metadata": {
     "papermill": {
-     "duration": 0.002914,
-     "end_time": "2023-11-02T14:59:55.277505",
+     "duration": 0.00454,
+     "end_time": "2023-11-02T15:25:33.538999",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.274591",
+     "start_time": "2023-11-02T15:25:33.534459",
      "status": "completed"
     },
     "tags": []
@@ -195,19 +195,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8247c396",
+   "id": "d227c239",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-11-02T14:59:55.285617Z",
-     "iopub.status.busy": "2023-11-02T14:59:55.284850Z",
-     "iopub.status.idle": "2023-11-02T14:59:55.363362Z",
-     "shell.execute_reply": "2023-11-02T14:59:55.361873Z"
+     "iopub.execute_input": "2023-11-02T15:25:33.551668Z",
+     "iopub.status.busy": "2023-11-02T15:25:33.550097Z",
+     "iopub.status.idle": "2023-11-02T15:25:33.723033Z",
+     "shell.execute_reply": "2023-11-02T15:25:33.721539Z"
     },
     "papermill": {
-     "duration": 0.085141,
-     "end_time": "2023-11-02T14:59:55.365716",
+     "duration": 0.182055,
+     "end_time": "2023-11-02T15:25:33.725929",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.280575",
+     "start_time": "2023-11-02T15:25:33.543874",
      "status": "completed"
     },
     "tags": []
@@ -271,7 +271,8 @@
     }
    ],
    "source": [
-    "input_data_path = '/kaggle/input/cyberbullying-classification/cyberbullying_tweets.csv'\n",
+    "#input_data_path = https://raw.githubusercontent.com/sgeinitz/CS39AA/main/data/trainB1.csv\n",
+    "input_data_path = 'https://raw.githubusercontent.com/Matthew-Bustamante/CS39AA-Project-Cyberbullying/main/cyberbullying_tweets.csv'\n",
     "\n",
     "cyberBullying = pd.read_csv(input_data_path, nrows=10000)\n",
     "cyberBullying.head(3)"
@@ -280,19 +281,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a5b7fdb4",
+   "id": "4a2df100",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-11-02T14:59:55.374138Z",
-     "iopub.status.busy": "2023-11-02T14:59:55.373803Z",
-     "iopub.status.idle": "2023-11-02T14:59:55.671766Z",
-     "shell.execute_reply": "2023-11-02T14:59:55.670248Z"
+     "iopub.execute_input": "2023-11-02T15:25:33.739392Z",
+     "iopub.status.busy": "2023-11-02T15:25:33.738984Z",
+     "iopub.status.idle": "2023-11-02T15:25:34.127108Z",
+     "shell.execute_reply": "2023-11-02T15:25:34.125778Z"
     },
     "papermill": {
-     "duration": 0.305051,
-     "end_time": "2023-11-02T14:59:55.674211",
+     "duration": 0.398472,
+     "end_time": "2023-11-02T15:25:34.129828",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.369160",
+     "start_time": "2023-11-02T15:25:33.731356",
      "status": "completed"
     },
     "tags": []
@@ -325,13 +326,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b24d125f",
+   "id": "b2e5df7e",
    "metadata": {
     "papermill": {
-     "duration": 0.003652,
-     "end_time": "2023-11-02T14:59:55.681670",
+     "duration": 0.005814,
+     "end_time": "2023-11-02T15:25:34.141347",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.678018",
+     "start_time": "2023-11-02T15:25:34.135533",
      "status": "completed"
     },
     "tags": []
@@ -342,13 +343,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c44d7b7f",
+   "id": "0b817bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.003264,
-     "end_time": "2023-11-02T14:59:55.688478",
+     "duration": 0.005333,
+     "end_time": "2023-11-02T15:25:34.152460",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.685214",
+     "start_time": "2023-11-02T15:25:34.147127",
      "status": "completed"
     },
     "tags": []
@@ -360,19 +361,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "af2c63ab",
+   "id": "b38eadea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-11-02T14:59:55.698142Z",
-     "iopub.status.busy": "2023-11-02T14:59:55.697568Z",
-     "iopub.status.idle": "2023-11-02T14:59:55.913520Z",
-     "shell.execute_reply": "2023-11-02T14:59:55.912144Z"
+     "iopub.execute_input": "2023-11-02T15:25:34.165597Z",
+     "iopub.status.busy": "2023-11-02T15:25:34.165213Z",
+     "iopub.status.idle": "2023-11-02T15:25:34.494329Z",
+     "shell.execute_reply": "2023-11-02T15:25:34.492961Z"
     },
     "papermill": {
-     "duration": 0.223906,
-     "end_time": "2023-11-02T14:59:55.916003",
+     "duration": 0.338734,
+     "end_time": "2023-11-02T15:25:34.496956",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.692097",
+     "start_time": "2023-11-02T15:25:34.158222",
      "status": "completed"
     },
     "tags": []
@@ -406,19 +407,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ec7c9a2c",
+   "id": "9403574a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-11-02T14:59:55.925487Z",
-     "iopub.status.busy": "2023-11-02T14:59:55.925143Z",
-     "iopub.status.idle": "2023-11-02T14:59:56.256591Z",
-     "shell.execute_reply": "2023-11-02T14:59:56.255203Z"
+     "iopub.execute_input": "2023-11-02T15:25:34.511380Z",
+     "iopub.status.busy": "2023-11-02T15:25:34.510965Z",
+     "iopub.status.idle": "2023-11-02T15:25:35.055761Z",
+     "shell.execute_reply": "2023-11-02T15:25:35.054474Z"
     },
     "papermill": {
-     "duration": 0.338428,
-     "end_time": "2023-11-02T14:59:56.258550",
+     "duration": 0.555877,
+     "end_time": "2023-11-02T15:25:35.059027",
      "exception": false,
-     "start_time": "2023-11-02T14:59:55.920122",
+     "start_time": "2023-11-02T15:25:34.503150",
      "status": "completed"
     },
     "tags": []
@@ -451,13 +452,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f126ad5",
+   "id": "3b514e27",
    "metadata": {
     "papermill": {
-     "duration": 0.003874,
-     "end_time": "2023-11-02T14:59:56.266805",
+     "duration": 0.006348,
+     "end_time": "2023-11-02T15:25:35.072227",
      "exception": false,
-     "start_time": "2023-11-02T14:59:56.262931",
+     "start_time": "2023-11-02T15:25:35.065879",
      "status": "completed"
     },
     "tags": []
@@ -487,14 +488,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.70298,
-   "end_time": "2023-11-02T14:59:56.691037",
+   "duration": 6.472538,
+   "end_time": "2023-11-02T15:25:35.601903",
    "environment_variables": {},
    "exception": null,
    "input_path": "__notebook__.ipynb",
    "output_path": "__notebook__.ipynb",
    "parameters": {},
-   "start_time": "2023-11-02T14:59:51.988057",
+   "start_time": "2023-11-02T15:25:29.129365",
    "version": "2.4.0"
   }
  },


### PR DESCRIPTION
Fixed the dataset file path to have so that is accesses the data from the main branch of this repository.  So if all goes well anyone who clicks on the 'open in kaggle' button should be able to run the entire note book and not come across any errors when accessing the data